### PR TITLE
解决selenium==4.1.0 和 appium-python-client 2.0.0依赖冲突问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-selenium==4.1.0
+selenium==4.0.0
 appium-python-client==2.0.0
 pillow==8.4.0
 apscheduler==3.8.0


### PR DESCRIPTION
改动文件：requirements.txt
改动原因：appium-python-client2.0.0 依赖于selenium=4.0.0，使用4.0.1会出现冲突