### PR TITLE
fix: Web trial-run preview uses user config and labels sandbox (#80)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2125,6 +2125,8 @@
         <span
           style="font-size:10px; font-weight:bold; color:var(--accent-cyan); background:rgba(6,182,212,0.1); padding:2px 6px; border-radius:4px; font-family:'JetBrains Mono';">WebDriver
           控制端</span>
+        <span id="sim-mode-badge"
+          style="display:none; font-size:10px; font-weight:bold; color:#b45309; background:rgba(245,158,11,0.15); padding:2px 6px; border-radius:4px; font-family:'JetBrains Mono'; margin-left:4px;">沙箱演示</span>
       </div>
 
       <div class="browser-content" id="webdriver-browser-screen">
@@ -2133,8 +2135,8 @@
         <div class="web-screen active" id="screen-idle">
           <div style="font-size:48px; margin-bottom:12px;">🖥️</div>
           <h3 style="font-size:14px; color:#475569; font-weight:600;">浏览器运行画面同步 (已闲置)</h3>
-          <p style="font-size:11px; color:#94a3b8; max-width:260px; margin-top:4px;">启动抢票任务后，此处将高保真同步 Selenium Chrome
-            实机渲染画面与点击点击流</p>
+          <p style="font-size:11px; color:#94a3b8; max-width:280px; margin-top:4px;">启动抢票任务后，此处展示流程预览画面。
+            若后端未联接或处于沙箱模式，显示的是<strong>演示数据</strong>，不会真实下单。</p>
         </div>
 
         <!-- Screen 1: Scan QR Login -->
@@ -2176,24 +2178,23 @@
             <div class="ticket-header-row">
               <div class="ticket-cover">票</div>
               <div class="ticket-meta-info">
-                <span class="ticket-badge-pill">大麦自营 / 实机选座</span>
-                <div class="ticket-title-text" id="screen-details-title">【成都站】超级明星2026世界巡回演唱会 - 抢购专场</div>
+                <span class="ticket-badge-pill" id="screen-details-badge">流程预览 / 沙箱演示</span>
+                <div class="ticket-title-text" id="screen-details-title">目标演出（将根据配置刷新）</div>
               </div>
             </div>
 
             <div style="font-size:11px; color:#475569; font-weight:600; margin-top:8px;">日期选择优先链:</div>
             <div class="ticket-attributes-grid" id="screen-details-dates">
-              <div class="ticket-attr-card active-target">2026-06-30 (周二) [优先]</div>
-              <div class="ticket-attr-card">2026-07-01 (周三) [备选]</div>
+              <div class="ticket-attr-card active-target">优先日期 [配置]</div>
+              <div class="ticket-attr-card">备选日期 [配置]</div>
             </div>
 
             <div style="font-size:11px; color:#475569; font-weight:600; margin-top:4px;">票档等级选择优先链:</div>
             <div class="ticket-attributes-grid" id="screen-details-prices">
-              <div class="ticket-attr-card">看台 480 元</div>
-              <div class="ticket-attr-card">看台 980 元</div>
-              <div class="ticket-attr-card active-target">内场 1280 元 [锁定]</div>
-              <div class="ticket-attr-card">内场 VIP 1680 元</div>
+              <div class="ticket-attr-card">票档策略 [配置]</div>
+              <div class="ticket-attr-card active-target">优先场次 [配置]</div>
             </div>
+            <p style="font-size:10px; color:#94a3b8; margin-top:8px;" id="screen-details-url-hint">目标链接: —</p>
           </div>
         </div>
 
@@ -2202,18 +2203,12 @@
           <div class="web-checkout-details">
             <h4
               style="font-size:13px; font-weight:700; color:#0f172a; border-bottom:1px solid #e2e8f0; padding-bottom:6px;">
-              订单确认提交 (buy.damai.cn)</h4>
+              订单确认提交流程预览 <span style="font-size:10px; color:#b45309; font-weight:600;">(沙箱演示 · 非真实下单)</span></h4>
 
-            <div style="font-size:11px; color:#475569; font-weight:600; margin-top:4px;">选定实名观演人:</div>
-            <div class="checkout-viewer-row">
+            <div style="font-size:11px; color:#475569; font-weight:600; margin-top:4px;">选定实名观演人索引 (来自配置):</div>
+            <div class="checkout-viewer-row" id="checkout-viewer-row">
               <div class="viewer-item-chip checked">
-                <span>✔</span> 张三 (1101**********1234)
-              </div>
-              <div class="viewer-item-chip checked">
-                <span>✔</span> 李四 (1102**********5678)
-              </div>
-              <div class="viewer-item-chip">
-                <span>○</span> 王五 (3101**********9999)
+                <span>✔</span> 观演人 #0
               </div>
             </div>
 
@@ -2222,11 +2217,12 @@
               <div>
                 <div style="font-weight:700; color:#0f172a;">购票数量: <span style="color:var(--accent-purple);"
                     id="checkout-qty">2 张</span></div>
-                <div style="color:var(--text-muted); margin-top:2px;">内场 1280 元 (成都市东安湖体育公园)</div>
+                <div style="color:var(--text-muted); margin-top:2px;" id="checkout-event-hint">目标演出将按配置展示</div>
               </div>
               <div
-                style="text-align:right; font-weight:700; color:var(--accent-pink); font-size:14px; align-self:center;">
-                ¥ 2560.00
+                style="text-align:right; font-weight:700; color:var(--accent-pink); font-size:12px; align-self:center;"
+                id="checkout-price-hint">
+                预览模式
               </div>
             </div>
           </div>
@@ -2235,11 +2231,12 @@
         <!-- Screen 5: Locked Ticket Modal Preview (Embedded) -->
         <div class="web-screen" id="screen-success-view">
           <div class="success-check-ring">✔</div>
-          <h3 style="font-size:14px; color:var(--success); font-weight:700; margin-top:10px;">抢购席位锁定成功！</h3>
-          <p style="font-size:11px; color:var(--text-muted); margin-top:4px;">订单编号: DM87654321908 | 席位: 内场A区10排8座</p>
+          <h3 style="font-size:14px; color:var(--success); font-weight:700; margin-top:10px;">沙箱流程走通成功</h3>
+          <p style="font-size:11px; color:var(--text-muted); margin-top:4px;" id="screen-success-detail">
+            这是演示预览，未产生真实订单。实机请运行 ticket_script.py / GUI。</p>
           <div
-            style="font-size:11px; font-weight:700; color:#ff6b00; margin-top:10px; padding:6px 14px; background:#fff8f3; border:1px solid rgba(255,107,0,0.15); border-radius:6px;">
-            请在 14分45秒 内完成付款完成出票
+            style="font-size:11px; font-weight:700; color:#b45309; margin-top:10px; padding:6px 14px; background:#fff8f3; border:1px solid rgba(245,158,11,0.25); border-radius:6px;">
+            沙箱演示 · 未真实下单 / 未扣款
           </div>
         </div>
 
@@ -2275,43 +2272,44 @@
 
     <div class="success-receipt-box" style="z-index: 101;">
       <div class="success-check-ring">✔</div>
-      <h2 style="font-size:18px; color:var(--success); font-weight:700; text-align:center;">🎟️ 抢票成功，订单已锁定！</h2>
-      <p style="font-size:12px; color:var(--text-muted); text-align:center; margin-top:-4px;">系统已为您秒杀锁定成都站内场黄金席位</p>
+      <h2 style="font-size:18px; color:var(--success); font-weight:700; text-align:center;">🎟️ 沙箱流程走通</h2>
+      <p style="font-size:12px; color:var(--text-muted); text-align:center; margin-top:-4px;" id="modal-success-subtitle">
+        当前为演示预览，未产生真实订单 / 未扣款</p>
 
       <!-- Receipt design -->
       <div
         style="width:100%; border-top:1px dashed #cbd5e1; border-bottom:1px dashed #cbd5e1; padding:12px 0; margin:10px 0; font-size:12px; line-height:1.8;">
         <div style="display:flex; justify-content:space-between;">
-          <span style="color:var(--text-muted);">购票演出:</span>
+          <span style="color:var(--text-muted);">目标演出:</span>
           <span
-            style="font-weight:600; color:#0f172a; max-width:160px; text-overflow:ellipsis; overflow:hidden; white-space:nowrap;"
-            id="modal-show-title">【成都站】超级明星世界巡演</span>
+            style="font-weight:600; color:#0f172a; max-width:180px; text-overflow:ellipsis; overflow:hidden; white-space:nowrap;"
+            id="modal-show-title">—</span>
         </div>
         <div style="display:flex; justify-content:space-between;">
-          <span style="color:var(--text-muted);">锁定场次:</span>
-          <span style="font-weight:600; color:#0f172a;">2026-06-30 周二 19:30</span>
+          <span style="color:var(--text-muted);">日期优先级:</span>
+          <span style="font-weight:600; color:#0f172a;" id="modal-show-date">—</span>
         </div>
         <div style="display:flex; justify-content:space-between;">
-          <span style="color:var(--text-muted);">所选价格:</span>
-          <span style="font-weight:600; color:#0f172a;">内场 1280 元 (2张)</span>
+          <span style="color:var(--text-muted);">场次 / 票数:</span>
+          <span style="font-weight:600; color:#0f172a;" id="modal-show-session">—</span>
         </div>
         <div style="display:flex; justify-content:space-between;">
-          <span style="color:var(--text-muted);">实名观演人:</span>
-          <span style="font-weight:600; color:#0f172a;">张三、李四</span>
+          <span style="color:var(--text-muted);">实名观演人索引:</span>
+          <span style="font-weight:600; color:#0f172a;" id="modal-show-viewers">—</span>
         </div>
         <div style="display:flex; justify-content:space-between;">
-          <span style="color:var(--text-muted);">所占座次:</span>
-          <span style="font-weight:600; color:var(--accent-purple);">内场 A区 10排 8-9座</span>
+          <span style="color:var(--text-muted);">运行模式:</span>
+          <span style="font-weight:600; color:var(--accent-purple);" id="modal-show-mode">沙箱演示</span>
         </div>
-        <div style="display:flex; justify-content:space-between; margin-top:6px; font-size:14px; font-weight:700;">
-          <span>应付总计:</span>
-          <span style="color:var(--accent-pink);">¥ 2560.00</span>
+        <div style="display:flex; justify-content:space-between; margin-top:6px; font-size:13px; font-weight:700;">
+          <span>说明:</span>
+          <span style="color:var(--accent-pink); font-size:12px;" id="modal-show-total">非真实下单</span>
         </div>
       </div>
 
       <div
-        style="font-size:11px; text-align:center; font-weight:700; color:#ff6b00; padding:6px 12px; background:#fff8f3; border:1px solid rgba(255,107,0,0.15); border-radius:6px; width:100%;">
-        支付剩余时间: <span id="payment-timer">14分59秒</span>
+        style="font-size:11px; text-align:center; font-weight:700; color:#b45309; padding:6px 12px; background:#fff8f3; border:1px solid rgba(245,158,11,0.25); border-radius:6px; width:100%;">
+        若要实机抢票，请运行 ticket_script.py 或桌面 GUI，并确保 Chrome/Cookie 已就绪
       </div>
 
       <div style="display:flex; gap:10px; width:100%; margin-top:8px;">
@@ -2774,6 +2772,121 @@
       appendLog("SYSTEM", "已导出环境依赖自检报告文本文件！", "info");
     }
 
+    // Build preview content from current form config (sandbox mock UI)
+    function getPreviewContext() {
+      const targetUrl = (document.getElementById("target_event_url")?.value || "").trim();
+      const ticketNum = parseInt(document.getElementById("target_tickets")?.value, 10) || 2;
+      const viewersRaw = (document.getElementById("target_viewers")?.value || "0").trim() || "0";
+      const datePriorities = (document.getElementById("target_date_priorities")?.value || "1").trim() || "1";
+      const sessionPriorities = (document.getElementById("target_session_priorities")?.value || "1").trim() || "1";
+      const priceRange = document.getElementById("target_price_range")?.value || "lowest_to_highest";
+      const mobile = (document.getElementById("account_mobile")?.value || "").trim() || "未填写";
+      const platform = document.getElementById("account_platform")?.value || "damai";
+      const autoBuy = !!document.getElementById("auto_buy_check")?.checked;
+
+      let showTitle = "目标演出（已按配置加载）";
+      if (targetUrl) {
+        try {
+          const u = new URL(targetUrl);
+          const id = u.searchParams.get("id") || u.pathname.split("/").filter(Boolean).pop() || "";
+          showTitle = id ? `目标演出 #${id}` : (u.hostname + u.pathname);
+        } catch (e) {
+          showTitle = targetUrl.length > 48 ? targetUrl.slice(0, 48) + "…" : targetUrl;
+        }
+      }
+
+      const viewerIndexes = viewersRaw.split(/[,，\s]+/).map(s => s.trim()).filter(Boolean);
+      return {
+        targetUrl: targetUrl || "未填写演出链接",
+        ticketNum,
+        viewersRaw,
+        viewerIndexes: viewerIndexes.length ? viewerIndexes : ["0"],
+        datePriorities,
+        sessionPriorities,
+        priceRange,
+        mobile,
+        platform,
+        autoBuy,
+        showTitle
+      };
+    }
+
+    function setSimModeBadge(visible) {
+      const badge = document.getElementById("sim-mode-badge");
+      if (badge) badge.style.display = visible ? "inline-block" : "none";
+    }
+
+    function applyPreviewToMockScreens(ctx) {
+      if (!ctx) ctx = getPreviewContext();
+
+      const titleEl = document.getElementById("screen-details-title");
+      if (titleEl) titleEl.textContent = ctx.showTitle;
+
+      const badgeEl = document.getElementById("screen-details-badge");
+      if (badgeEl) badgeEl.textContent = "流程预览 / 沙箱演示";
+
+      const datesEl = document.getElementById("screen-details-dates");
+      if (datesEl) {
+        const dates = ctx.datePriorities.split(/[,，\s]+/).map(s => s.trim()).filter(Boolean);
+        datesEl.innerHTML = (dates.length ? dates : ["1"]).map((d, i) =>
+          `<div class="ticket-attr-card${i === 0 ? " active-target" : ""}">日期优先级 #${d}${i === 0 ? " [优先]" : ""}</div>`
+        ).join("");
+      }
+
+      const pricesEl = document.getElementById("screen-details-prices");
+      if (pricesEl) {
+        const sessions = ctx.sessionPriorities.split(/[,，\s]+/).map(s => s.trim()).filter(Boolean);
+        pricesEl.innerHTML = [
+          `<div class="ticket-attr-card">票档策略: ${ctx.priceRange}</div>`,
+          ...(sessions.length ? sessions : ["1"]).map((s, i) =>
+            `<div class="ticket-attr-card${i === 0 ? " active-target" : ""}">场次优先级 #${s}${i === 0 ? " [锁定]" : ""}</div>`
+          )
+        ].join("");
+      }
+
+      const urlHint = document.getElementById("screen-details-url-hint");
+      if (urlHint) urlHint.textContent = `目标链接: ${ctx.targetUrl}`;
+
+      const qtyEl = document.getElementById("checkout-qty");
+      if (qtyEl) qtyEl.textContent = `${ctx.ticketNum} 张`;
+
+      const eventHint = document.getElementById("checkout-event-hint");
+      if (eventHint) eventHint.textContent = ctx.showTitle;
+
+      const priceHint = document.getElementById("checkout-price-hint");
+      if (priceHint) priceHint.textContent = "预览模式";
+
+      const viewerRow = document.getElementById("checkout-viewer-row");
+      if (viewerRow) {
+        viewerRow.innerHTML = ctx.viewerIndexes.map(idx =>
+          `<div class="viewer-item-chip checked"><span>✔</span> 观演人索引 #${idx}</div>`
+        ).join("");
+      }
+
+      const successDetail = document.getElementById("screen-success-detail");
+      if (successDetail) {
+        successDetail.textContent = `配置预览 · ${ctx.showTitle} · ${ctx.ticketNum} 张 · 索引 [${ctx.viewersRaw}]（非真实订单）`;
+      }
+    }
+
+    function fillSuccessModalFromConfig(ctx, modeLabel) {
+      if (!ctx) ctx = getPreviewContext();
+      const mode = modeLabel || "沙箱演示";
+
+      const setText = (id, text) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = text;
+      };
+
+      setText("modal-show-title", ctx.showTitle);
+      setText("modal-show-date", `优先级 [${ctx.datePriorities}]`);
+      setText("modal-show-session", `场次 [${ctx.sessionPriorities}] · ${ctx.ticketNum} 张`);
+      setText("modal-show-viewers", `索引 [${ctx.viewersRaw}]（非真实姓名）`);
+      setText("modal-show-mode", mode);
+      setText("modal-show-total", "非真实下单 / 未扣款");
+      setText("modal-success-subtitle", `当前为 ${mode}，按你的配置展示流程预览，不会产生真实订单`);
+    }
+
     // UI WebDriver screen mirroring state switcher
     function switchWebdriverScreen(screenId, url = "") {
       const screens = ['screen-idle', 'screen-login', 'screen-captcha', 'screen-details', 'screen-checkout', 'screen-success-view'];
@@ -2789,6 +2902,10 @@
       }
       if (url) {
         document.getElementById('browser-address-bar').textContent = url;
+      }
+      // Keep mock screens in sync with latest form config whenever details/checkout show
+      if (screenId === "screen-details" || screenId === "screen-checkout" || screenId === "screen-success-view") {
+        applyPreviewToMockScreens(getPreviewContext());
       }
     }
 
@@ -3227,6 +3344,7 @@
     function closeSuccessModal() {
       document.getElementById('success-modal').classList.remove('active');
       if (confettiIntervalId) clearInterval(confettiIntervalId);
+      setSimModeBadge(false);
       switchWebdriverScreen('screen-idle', 'chrome://newtab/');
     }
 
@@ -3293,18 +3411,16 @@
               } else if (log.message.includes("实名观演人") || log.message.includes("buy.damai.cn")) {
                 switchWebdriverScreen("screen-checkout", "https://buy.damai.cn/orderconfirm");
                 highlightFlowNode("node-order");
-              } else if (log.message.includes("SUCCESS") || log.message.includes("抢票成功")) {
+              } else if (log.message.includes("SUCCESS") || log.message.includes("抢票成功") || log.message.includes("沙箱流程走通")) {
                 switchWebdriverScreen("screen-success-view", "https://buy.damai.cn/ordersuccess");
                 highlightFlowNode("node-order", "success-node");
 
-                // Launch premium client WOW factor ticket overlay modal!
+                // Launch preview modal filled from current form config (not hardcoded demo show)
                 setTimeout(() => {
+                  const ctx = getPreviewContext();
+                  applyPreviewToMockScreens(ctx);
+                  fillSuccessModalFromConfig(ctx, "后端沙箱演示");
                   document.getElementById('success-modal').classList.add('active');
-                  // Fill modal info based on configuration inputs
-                  const url = document.getElementById('target_event_url').value;
-                  const qty = document.getElementById('target_tickets').value || 2;
-                  document.getElementById('checkout-qty').textContent = `${qty} 张`;
-                  document.getElementById('modal-show-title').textContent = "【成都市东安湖体育公园】2026超级演出";
                   triggerConfetti();
                 }, 1200);
               }
@@ -3325,9 +3441,10 @@
             document.getElementById("retry-btn").disabled = (data.status !== 'completed');
 
             let stateText = "未开始";
-            if (data.status === 'completed') stateText = "任务完成";
+            if (data.status === 'completed') stateText = "沙箱演示完成";
             if (data.status === 'stopped') {
               stateText = "任务已停止";
+              setSimModeBadge(false);
               highlightFlowNode("", "idle");
               switchWebdriverScreen("screen-idle", "chrome://newtab/");
             }
@@ -3385,13 +3502,16 @@
         })
         .then(res => {
           if (!res.ok) throw new Error("HTTP error starting task");
-          appendLog("SYSTEM", "🎉 成功联接 Python 后端！实机自动化抢票任务已启动。", "system");
+          appendLog("SYSTEM", "已联接 Python 后端。注意：当前 web_server 仍为流程沙箱，日志为模拟输出，不会真实 Selenium 下单。", "warning");
+          setSimModeBadge(true);
+          applyPreviewToMockScreens(getPreviewContext());
           pollBackendLogs();
         })
         .catch(err => {
           // Fallback to local high-fidelity sandbox runner for client showcase
           appendLog("SYSTEM", `未探测到活跃的 Python 运行端口: ${err.message}`, "warning");
-          appendLog("SYSTEM", "⚠️ 将以本地高保真沙箱状态机执行调度，演示完整业务流程...", "warning");
+          appendLog("SYSTEM", "⚠️ 将以本地高保真【沙箱演示】执行：预览按你的配置渲染，不会真实抢票。", "warning");
+          setSimModeBadge(true);
 
           const autoInstall = document.getElementById("dep_auto_install").checked;
           const packages = getDependenciesList();
@@ -3399,11 +3519,11 @@
           if (autoInstall && packages.length > 0) {
             appendLog("SYSTEM", "检测到开启了依赖自检，优先执行环境检查...", "info");
             runDependencyInstallationSim(packages, () => {
-              appendLog("SYSTEM", "环境自检通过。正在启动 Chrome WebDriver 指纹防御器...", "system");
+              appendLog("SYSTEM", "环境自检通过。正在启动沙箱流程预览...", "system");
               setTimeout(startCoreTicketingFlow, 500);
             });
           } else {
-            appendLog("SYSTEM", "直接启动 Chrome WebDriver 指纹防御器...", "system");
+            appendLog("SYSTEM", "直接启动沙箱流程预览...", "system");
             setTimeout(startCoreTicketingFlow, 200);
           }
         });
@@ -3412,35 +3532,42 @@
     function startCoreTicketingFlow() {
       if (!ticketingActive) return;
 
-      const platform = document.getElementById("account_platform").value;
-      const mobile = document.getElementById("account_mobile").value || "13888888888";
-      const targetUrl = document.getElementById("target_event_url").value;
-      const datePriorities = document.getElementById("target_date_priorities").value || "1";
-      const sessionPriorities = document.getElementById("target_session_priorities").value || "1";
-      const ticketNum = parseInt(document.getElementById("target_tickets").value) || 2;
-      const viewers = document.getElementById("target_viewers").value || "0";
-      const autoBuy = document.getElementById("auto_buy_check").checked;
+      setSimModeBadge(true);
+      const ctx = getPreviewContext();
+      applyPreviewToMockScreens(ctx);
+
+      const platform = ctx.platform;
+      const mobile = ctx.mobile;
+      const targetUrl = ctx.targetUrl;
+      const datePriorities = ctx.datePriorities;
+      const sessionPriorities = ctx.sessionPriorities;
+      const ticketNum = ctx.ticketNum;
+      const viewers = ctx.viewersRaw;
+      const autoBuy = ctx.autoBuy;
       const proxyAddr = document.getElementById("proxy_addr").value;
-      const useAi = document.getElementById("strategy_ai").checked;
+      const detailUrl = (targetUrl && targetUrl.startsWith("http")) ? targetUrl : "https://detail.damai.cn/";
+
+      appendLog("SYSTEM", "⚠️ 当前为本地高保真【沙箱演示】：预览画面与弹窗按你的配置渲染，不会真实登录/下单。", "warning");
+      appendLog("SYSTEM", `预览配置 → 演出: ${ctx.showTitle} | 票数: ${ticketNum} | 观演人索引: [${viewers}]`, "info");
 
       const flowSteps = [
-        { progress: 5, level: "INFO", text: `正在连接代理路由服务器: ${proxyAddr || "直连模式 (DIRECT)"}`, action: () => highlightFlowNode("node-fingerprint") },
-        { progress: 10, level: "SYSTEM", text: "已注入 Selenium 隐身防御补丁 (--disable-blink-features=AutomationControlled)", action: () => switchWebdriverScreen("screen-idle", "chrome://newtab/") },
-        { progress: 18, level: "INFO", text: `正在导航并拉取平台 [${platform.toUpperCase()}] 的演出详情页...`, action: () => switchWebdriverScreen("screen-login", "https://passport.damai.cn/login") },
-        { progress: 24, level: "DEBUG", text: `目标购票地址: ${targetUrl}` },
-        { progress: 32, level: "INFO", text: "检查本地 Cookie 缓存 (cookies.pkl) 可用性..." },
-        { progress: 40, level: "SYSTEM", text: `### 扫码登录引导 ### 绑定手机: ${mobile}，请在移动端完成扫码授权...` },
+        { progress: 5, level: "INFO", text: `[沙箱] 模拟连接代理路由: ${proxyAddr || "直连模式 (DIRECT)"}`, action: () => highlightFlowNode("node-fingerprint") },
+        { progress: 10, level: "SYSTEM", text: "[沙箱] 模拟注入 Selenium 隐身防御补丁 (--disable-blink-features=AutomationControlled)", action: () => switchWebdriverScreen("screen-idle", "chrome://newtab/") },
+        { progress: 18, level: "INFO", text: `[沙箱] 模拟导航平台 [${platform.toUpperCase()}] 演出详情页...`, action: () => switchWebdriverScreen("screen-login", "https://passport.damai.cn/login") },
+        { progress: 24, level: "DEBUG", text: `目标购票地址 (来自配置): ${targetUrl}` },
+        { progress: 32, level: "INFO", text: "[沙箱] 检查本地 Cookie 缓存 (cookies.pkl) 可用性..." },
+        { progress: 40, level: "SYSTEM", text: `### 扫码登录引导 (演示) ### 绑定手机: ${mobile}` },
         {
-          progress: 48, level: "INFO", text: "Cookies 同步成功！已保存至 cookies.pkl", action: () => {
-            switchWebdriverScreen("screen-details", "https://detail.damai.cn/item.htm?id=80456123490");
+          progress: 48, level: "INFO", text: "[沙箱] Cookies 同步成功（演示，未真实扫码）", action: () => {
+            switchWebdriverScreen("screen-details", detailUrl);
             highlightFlowNode("node-mouse");
           }
         },
-        { progress: 56, level: "DEBUG", text: "### 载入 Cookie 验证状态成功 ### 正在刷新具体演出页面..." },
-        { progress: 64, level: "INFO", text: `正在解析日历卡片与票档。策略: 优先日期 [${datePriorities}], 优先场次 [${sessionPriorities}]` },
+        { progress: 56, level: "DEBUG", text: "### 载入 Cookie 验证状态成功 (演示) ### 正在刷新具体演出页面..." },
+        { progress: 64, level: "INFO", text: `正在解析日历卡片与票档 (配置)。策略: 优先日期 [${datePriorities}], 优先场次 [${sessionPriorities}]` },
         {
-          progress: 70, level: "INFO", text: `检测到安全滑块盾保护，AI 神经网络指纹模块介入...`, action: () => {
-            switchWebdriverScreen("screen-captcha", "https://detail.damai.cn/item.htm?id=80456123490");
+          progress: 70, level: "INFO", text: `[沙箱] 检测到安全滑块盾保护，模拟 AI 滑块校验...`, action: () => {
+            switchWebdriverScreen("screen-captcha", detailUrl);
             highlightFlowNode("node-captcha");
             setTimeout(() => {
               const thumb = document.getElementById('captcha-slider-thumb');
@@ -3455,38 +3582,38 @@
           }
         },
         {
-          progress: 80, level: "INFO", text: "滑块盾验证突破成功！耗时 240ms。正在加载订单结算页...", action: () => {
+          progress: 80, level: "INFO", text: "[沙箱] 滑块校验模拟完成。正在加载订单结算页预览...", action: () => {
             highlightFlowNode("node-order");
           }
         },
         {
-          progress: 88, level: "INFO", text: `选择购票数: [${ticketNum} 张]。自动勾选实名观演人索引: [${viewers}]`, action: () => {
-            document.getElementById('checkout-qty').textContent = `${ticketNum} 张`;
+          progress: 88, level: "INFO", text: `选择购票数: [${ticketNum} 张]。自动勾选实名观演人索引: [${viewers}]（索引来自配置，非固定姓名）`, action: () => {
+            applyPreviewToMockScreens(ctx);
             switchWebdriverScreen("screen-checkout", "https://buy.damai.cn/orderconfirm");
           }
         },
-        { progress: 95, level: "SYSTEM", text: `准备就绪。正在以极速自动出手 (Auto Strike) 模式提交订单包...` }
+        { progress: 95, level: "SYSTEM", text: `[沙箱] 准备模拟 ${autoBuy ? "Auto Strike 提交" : "选座完成"}...` }
       ];
 
       if (autoBuy) {
         flowSteps.push(
           {
-            progress: 100, level: "INFO", text: "🎉 [SUCCESS] 订单提交成功！服务器响应 200 OK。", action: () => {
+            progress: 100, level: "INFO", text: "🎉 [SUCCESS] 沙箱流程走通（演示成功，未真实下单）。", action: () => {
               switchWebdriverScreen("screen-success-view", "https://buy.damai.cn/ordersuccess");
               highlightFlowNode("node-order", "success-node");
 
-              // Trigger WOW Confetti modal overlay
               setTimeout(() => {
+                fillSuccessModalFromConfig(ctx, "本地沙箱演示");
                 document.getElementById('success-modal').classList.add('active');
                 triggerConfetti();
               }, 1000);
             }
           },
-          { progress: 100, level: "SYSTEM", text: "🎟️ 抢票成功！已为您锁定该场次座位，请在规定时间内前往平台完成付款！" }
+          { progress: 100, level: "SYSTEM", text: "🎟️ 沙箱演示结束。实机抢票请运行 ticket_script.py 或桌面 GUI，并确认 Chrome/Cookie。" }
         );
       } else {
         flowSteps.push(
-          { progress: 100, level: "WARNING", text: "[INFO] 未启用自动下单。仅执行自动化选座, 请在弹出的浏览器界面上人工点击'提交订单'完成购买。" }
+          { progress: 100, level: "WARNING", text: "[沙箱] 未启用自动下单。演示仅模拟选座，实机需人工提交订单。" }
         );
       }
 
@@ -3499,7 +3626,7 @@
           document.getElementById("start-btn").disabled = false;
           document.getElementById("stop-btn").disabled = true;
           document.getElementById("retry-btn").disabled = false;
-          updateStatusUI("completed", "任务完成");
+          updateStatusUI("completed", "沙箱演示完成");
           updateProgressUI(100);
           return;
         }
@@ -3522,6 +3649,7 @@
       ticketingActive = false;
       isSimulationRunning = false;
       if (logPollTimeoutId) clearTimeout(logPollTimeoutId);
+      setSimModeBadge(false);
       highlightFlowNode("", "idle");
       switchWebdriverScreen("screen-idle", "chrome://newtab/");
 

--- a/web_server.py
+++ b/web_server.py
@@ -82,7 +82,7 @@ class DashboardHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
             with state_lock:
                 stop_flag = True
                 status = "stopped"
-            add_log("SYSTEM", "收到用户主动终止任务指令，正在安全关闭抢票进程与浏览器资源...", "ERROR")
+            add_log("SYSTEM", "收到用户主动终止任务指令，正在安全关闭抢票进程与浏览器资源...")
             self.wfile.write(json.dumps({"status": "stopped"}).encode('utf-8'))
 
         elif self.path == '/api/dependencies/install':
@@ -181,7 +181,7 @@ def dependency_install_worker_thread(packages):
             status = "idle"
         return
 
-    add_log("SYSTEM", "开始进行环境运行包依赖部署及版本自检...", "INFO")
+    add_log("SYSTEM", "开始进行环境运行包依赖部署及版本自检...")
     step_count = 0
     total_steps = total_packages * len(dependencySteps)
 
@@ -202,19 +202,68 @@ def dependency_install_worker_thread(packages):
     with state_lock:
         progress = 100
         status = "completed"
-    add_log("SYSTEM", "环境依赖安装及配置成功！", "INFO")
+    add_log("SYSTEM", "环境依赖安装及配置成功！")
 
 def ticketing_worker_thread():
     global status, progress, stop_flag
-    
+
+    # Load user config so logs reflect real settings (still a sandbox — no real purchase)
+    target_url = ""
+    tickets = 2
+    viewers = [0, 1]
+    platform = "damai"
+    mobile = ""
+    date_priorities = [1]
+    session_priorities = [1]
+    auto_buy = True
+    try:
+        config_file = "config/config.json"
+        if not os.path.exists(config_file):
+            config_file = "config/demo_config.json"
+        if os.path.exists(config_file):
+            with open(config_file, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            auto_buy = cfg.get("strategy", {}).get("auto_strike", True)
+            acc = (cfg.get("accounts") or {}).get("acc_primary") or {}
+            platform = acc.get("platform") or platform
+            creds = acc.get("credentials") or {}
+            mobile = creds.get("mobile") or ""
+            target = acc.get("target") or {}
+            target_url = target.get("event_url") or ""
+            tickets = target.get("tickets") or tickets
+            viewers = target.get("viewers") or viewers
+            priorities = target.get("priorities") or {}
+            date_priorities = priorities.get("date") or date_priorities
+            session_priorities = priorities.get("session") or session_priorities
+    except Exception as e:
+        print("Read config err:", e)
+
+    add_log(
+        "WARNING",
+        "当前为 Web 控制台【沙箱演示】：不会打开真实浏览器、不会真实下单。"
+        " 预览画面中的城市/姓名若曾写死为示例文案，已改为按 config 渲染。"
+        " 实机请运行 ticket_script.py 或桌面 GUI。",
+    )
+    add_log(
+        "INFO",
+        f"读取配置 → 平台={platform} 手机={mobile or '未填写'} "
+        f"票数={tickets} 观演人索引={viewers} "
+        f"日期优先级={date_priorities} 场次优先级={session_priorities}",
+    )
+    if target_url:
+        add_log("INFO", f"目标演出链接 (来自配置): {target_url}")
+    else:
+        add_log("WARNING", "配置中未填写 target.event_url，预览将使用占位标题。")
+
     steps = [
-        (5, "INFO", "正在连接代理路由服务器..."),
-        (10, "SYSTEM", "已注入 Selenium 隐身防御补丁 (--disable-blink-features=AutomationControlled)"),
-        (15, "INFO", "正在初始化 Chrome WebDriver 浏览器控制端..."),
+        (5, "INFO", "[沙箱] 模拟连接代理路由服务器..."),
+        (10, "SYSTEM", "[沙箱] 模拟注入 Selenium 隐身防御补丁 (--disable-blink-features=AutomationControlled)"),
+        (15, "INFO", "[沙箱] 模拟初始化 Chrome WebDriver（未真实启动浏览器）..."),
     ]
 
     for p, lvl, msg in steps:
-        if stop_flag: return
+        if stop_flag:
+            return
         with state_lock:
             progress = p
         add_log(lvl, msg)
@@ -223,56 +272,65 @@ def ticketing_worker_thread():
     # Core Environment Dependency Check
     chrome_ok = True
     try:
-        import selenium
-        from selenium import webdriver
+        import selenium  # noqa: F401
+        from selenium import webdriver  # noqa: F401
     except ImportError:
         chrome_ok = False
-        add_log("WARNING", "运行环境中未检测到 [selenium] 库。将使用内置的防指纹检测核心接托管。")
-    
-    # ChromeDriver Check
+        add_log("WARNING", "运行环境中未检测到 [selenium] 库。沙箱演示可继续，实机抢票需先安装依赖。")
+
     driver_file = "chromedriver.exe" if sys.platform.startswith("win") else "chromedriver"
     if not os.path.exists(driver_file):
-        add_log("WARNING", f"本地根目录下未检测到驱动 [{driver_file}]。将自动定位系统默认路径的 Chrome 浏览器内核。")
+        add_log(
+            "WARNING",
+            f"本地根目录下未检测到驱动 [{driver_file}]。沙箱演示不依赖驱动；实机将尝试系统 Chrome。",
+        )
+    if chrome_ok:
+        add_log("DEBUG", "selenium 已安装（本线程仍不执行真实抢票）。")
 
     flow = [
-        (25, "INFO", "正在解析账户登录 Cookies 凭证信息 (cookies.pkl)..."),
-        (32, "WARNING", "本地未检测到 cookies.pkl 授权缓存。正在启动扫码登录安全防护窗口..."),
-        (40, "SYSTEM", "### 扫码登录引导 ### 请在弹出的浏览器界面中扫描二维码以同步大麦网账户授权..."),
-        (48, "INFO", "同步大麦网 Cookies 凭证成功，已持久化写入本地 cookies.pkl"),
-        (55, "DEBUG", "### 载入 Cookie 验证状态成功 ### 正在向购票目标页面进行跳转..."),
-        (62, "INFO", "正在解析日历票档卡片... 读取场次与日期优先级列表"),
-        (72, "INFO", "正在检索余票状态... 余票可用！正在勾选对应的实名观演人复选框"),
-        (85, "SYSTEM", "### 极速自动出手 (Auto Strike) ### 提交抢购订单包中...")
+        (25, "INFO", "[沙箱] 模拟解析账户 Cookies (cookies.pkl)..."),
+        (32, "WARNING", "[沙箱] 演示路径：若无 cookies.pkl，实机将弹出扫码登录窗口"),
+        (40, "SYSTEM", f"### 扫码登录引导 (演示) ### 绑定手机: {mobile or '未填写'}"),
+        (48, "INFO", "[沙箱] 模拟 Cookies 同步成功（未真实扫码）"),
+        (55, "DEBUG", "### 载入 Cookie 验证状态成功 (演示) ### 正在向购票目标页面进行跳转..."),
+        (
+            62,
+            "INFO",
+            f"正在解析日历票档卡片... 日期优先级={date_priorities} 场次优先级={session_priorities}",
+        ),
+        (
+            72,
+            "INFO",
+            f"正在检索余票状态... 模拟勾选实名观演人索引 {viewers}（索引来自配置，非固定姓名如「张三」）",
+        ),
+        (85, "SYSTEM", "### 极速自动出手 (Auto Strike · 沙箱) ### 模拟提交订单包中..."),
     ]
 
     for p, lvl, msg in flow:
-        if stop_flag: return
+        if stop_flag:
+            return
         with state_lock:
             progress = p
         add_log(lvl, msg)
         time.sleep(0.7)
 
-    # Read configuration auto_buy settings
-    auto_buy = True
-    try:
-        config_file = "config/config.json"
-        if os.path.exists(config_file):
-            with open(config_file, "r", encoding="utf-8") as f:
-                cfg = json.load(f)
-                auto_buy = cfg.get("strategy", {}).get("auto_strike", True)
-    except Exception as e:
-        print("Read config err:", e)
-
-    if stop_flag: return
+    if stop_flag:
+        return
     with state_lock:
         progress = 100
         status = "completed"
 
     if auto_buy:
-        add_log("INFO", "🎉 [SUCCESS] 订单提交成功！大麦接口返回状态码 200 OK。")
-        add_log("SYSTEM", "🎟️ 抢票成功！已为您锁定该场次座位，请在规定时间内前往平台完成付款！")
+        add_log("INFO", "🎉 [SUCCESS] 沙箱流程走通（演示成功，未真实下单 / 未扣款）。")
+        add_log(
+            "SYSTEM",
+            "🎟️ 沙箱演示结束。实机抢票请运行: python ticket_script.py 或桌面 GUI，并确认 Chrome/Cookie 就绪。",
+        )
     else:
-        add_log("WARNING", "[INFO] 未启用自动秒杀下单。已为您执行自动化选座，请在弹出的浏览器界面上手工提交订单。")
+        add_log(
+            "WARNING",
+            "[沙箱] 未启用自动秒杀下单。演示仅模拟选座；实机需在浏览器中人工提交订单。",
+        )
 
 def main():
     # Force working directory to the directory containing this script


### PR DESCRIPTION
## Summary
- Web trial-run used hardcoded demo copy (Chengdu station / Zhang San), so users thought their account config was ignored (#80).
- Preview screens and success modal now render from form/config (event URL, tickets, date/session priorities, viewer indices) and clearly label sandbox mode (no real purchase).
- `web_server.py` logs read `config.json` and declare sandbox mode.

## Test plan
- [ ] Start `python web_server.py`, set custom event URL / ticket count / viewer indices, click start
- [ ] Confirm preview title, ticket count, viewer chips and success modal come from config (no Chengdu/Zhang San)
- [ ] Confirm logs contain sandbox wording and status is sandbox-complete
- [ ] Local sandbox fallback without backend still uses config
- [ ] Opening `web/index.html` directly still works

Closes #80